### PR TITLE
Refactor: Change create diary logic

### DIFF
--- a/server/src/main/java/com/jongyeop/soompyo/diary/controller/DiaryController.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/controller/DiaryController.java
@@ -1,26 +1,27 @@
 package com.jongyeop.soompyo.diary.controller;
 
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.jongyeop.soompyo.diary.dto.DiaryDto;
 import com.jongyeop.soompyo.diary.model.Diary;
-import com.jongyeop.soompyo.diary.repository.DiaryRepository;
+import com.jongyeop.soompyo.diary.service.DiaryService;
 
-@Controller
+@RestController
 @RequestMapping("/diarys")
 public class DiaryController {
-	private final DiaryRepository diaryRepository;
+	private final DiaryService diaryService;
 
-	public DiaryController(DiaryRepository diaryRepository) {
-		this.diaryRepository = diaryRepository;
+	public DiaryController(DiaryService diaryService) {
+		this.diaryService = diaryService;
 	}
 
 	@PostMapping
-	public DiaryDto saveDiary(Diary diary) {
-		Diary savedDiary = diaryRepository.save(diary);
-		return new DiaryDto(savedDiary.getId(), savedDiary.getOwner(), savedDiary.getTitle(),
+	public DiaryDto saveDiary(@RequestBody DiaryDto diary) {
+		Diary savedDiary = diaryService.save(diary);
+		return new DiaryDto(savedDiary.getId(), savedDiary.getOwner().getId(), savedDiary.getTitle(),
 			savedDiary.getContent(),
 			savedDiary.getCreatedDate(), savedDiary.getModifiedDate());
 	}

--- a/server/src/main/java/com/jongyeop/soompyo/diary/dto/DiaryDto.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/dto/DiaryDto.java
@@ -2,17 +2,15 @@ package com.jongyeop.soompyo.diary.dto;
 
 import java.time.LocalDateTime;
 
-import com.jongyeop.soompyo.user.model.TempUser;
-
 public class DiaryDto {
 	private final Long id;
-	private final TempUser owner;
+	private final Long owner;
 	private final String title;
 	private final String content;
 	private final LocalDateTime createdDate;
 	private final LocalDateTime modifiedDate;
 
-	public DiaryDto(Long id, TempUser owner, String title, String content, LocalDateTime createdDate,
+	public DiaryDto(Long id, Long owner, String title, String content, LocalDateTime createdDate,
 		LocalDateTime modifiedDate) {
 		this.id = id;
 		this.owner = owner;
@@ -26,7 +24,7 @@ public class DiaryDto {
 		return id;
 	}
 
-	public TempUser getOwner() {
+	public Long getOwner() {
 		return owner;
 	}
 

--- a/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryService.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryService.java
@@ -1,7 +1,8 @@
 package com.jongyeop.soompyo.diary.service;
 
+import com.jongyeop.soompyo.diary.dto.DiaryDto;
 import com.jongyeop.soompyo.diary.model.Diary;
 
 public interface DiaryService {
-	Diary save(Diary diary);
+	Diary save(DiaryDto diary);
 }

--- a/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryServiceImpl.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryServiceImpl.java
@@ -1,9 +1,15 @@
 package com.jongyeop.soompyo.diary.service;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 
+import com.jongyeop.soompyo.diary.dto.DiaryDto;
 import com.jongyeop.soompyo.diary.model.Diary;
 import com.jongyeop.soompyo.diary.repository.DiaryRepository;
+import com.jongyeop.soompyo.user.model.TempUser;
+import com.jongyeop.soompyo.user.repository.UserRepository;
 
 import jakarta.transaction.Transactional;
 
@@ -11,12 +17,17 @@ import jakarta.transaction.Transactional;
 @Transactional
 public class DiaryServiceImpl implements DiaryService {
 	private final DiaryRepository diaryRepository;
+	private final UserRepository userRepository;
 
-	public DiaryServiceImpl(DiaryRepository diaryRepository) {
+	public DiaryServiceImpl(DiaryRepository diaryRepository, UserRepository userRepository) {
 		this.diaryRepository = diaryRepository;
+		this.userRepository = userRepository;
 	}
+
 	@Override
-	public Diary save(Diary diary) {
+	public Diary save(DiaryDto diaryDto) {
+		Optional<TempUser> findUser = userRepository.findById(diaryDto.getOwner());
+		Diary diary = new Diary(findUser.get(), diaryDto.getTitle(), diaryDto.getContent(), LocalDateTime.now(), null);
 		return diaryRepository.save(diary);
 	}
 }

--- a/server/src/test/java/com/jongyeop/soompyo/diary/service/DiaryServiceTest.java
+++ b/server/src/test/java/com/jongyeop/soompyo/diary/service/DiaryServiceTest.java
@@ -1,6 +1,7 @@
 package com.jongyeop.soompyo.diary.service;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import com.jongyeop.soompyo.diary.dto.DiaryDto;
 import com.jongyeop.soompyo.diary.model.Diary;
 import com.jongyeop.soompyo.diary.repository.DiaryRepository;
 import com.jongyeop.soompyo.user.model.TempUser;
@@ -24,32 +26,33 @@ public class DiaryServiceTest {
 	private DiaryRepository diaryRepository;
 
 	@BeforeEach
-	public void beforeEach(){
+	public void beforeEach() {
 		tempUserService
 			= new TempUserServiceImpl(tempUserRepository);
-		diaryService = new DiaryServiceImpl(diaryRepository);
+		diaryService = new DiaryServiceImpl(diaryRepository, tempUserRepository);
 	}
 
 	@Test
-	public void CreateDiaryTest(){
-	    //given
-		TempUser tempUser = new TempUser("Test", "TestName");
-	    tempUserService.join(tempUser);
+	public void CreateDiaryTest() {
+		//given
+		TempUser tempUser = new TempUser("Test", "testName");
+		tempUserRepository.saveAndFlush(tempUser); // 테스트를 위해 저장 후 플러시 작업을 수행
 
 		String title = "Diary Test";
 		String content = "This is diary Test";
-		LocalDateTime createdDate = LocalDateTime.now();
-		Diary diary = new Diary(tempUser, title, content, createdDate, null);
+
+		Optional<TempUser> findUser = tempUserService.findByUsername("testName");
 
 		//when
+		if(!findUser.isPresent()) {
+			throw new RuntimeException("사용자를 찾을 수 없습니다.");
+		}
+		DiaryDto diary = new DiaryDto(null, findUser.get().getId(), title, content, null, null);
 		Diary savedDiary = diaryService.save(diary);
 
 		//then
-		Assertions.assertThat(savedDiary.getId()).isEqualTo(diary.getId());
 		Assertions.assertThat(savedDiary.getTitle()).isEqualTo(title);
 		Assertions.assertThat(savedDiary.getContent()).isEqualTo(content);
-		Assertions.assertThat(savedDiary.getCreatedDate()).isEqualTo(createdDate);
-
 	}
 
 }


### PR DESCRIPTION
[개요]
- API 서버이기 때문에 Controller를 사용할 경우 일일히 @ResponseBody 어노테이션을 붙여줘야 하는 문제 발생
- DiaryDto의 잘못된 타입 매핑(owner 필드)으로 인해 로직에 대한 문제점 발견
- 위 문제 해결을 위해 바뀐 로직으로 테스트할 수 있도록 수정

[수정사항]
- DiaryController의 Controller 어노테이션을 RestController로 변경
- 기존에 DiaryDto -> Diary 변환 과정을 Controller에서 Service로 변경
  - _이후 Builder 변경 예정_
- DiaryDto의 owner 필드의 타입을 TempUser에서 Long(owner ID)로 변경
- Test: TempUser 객체를 생성 및 플러시 하는 로직 추가

[결과]
- API에 적합한 반환 방식으로 변경
- DiaryDto에서 사용자 ID를 저장하도록 변경
- 변경된 로직에 맞는 TEST 구현