### PR TITLE
Refactor: 일기 엔티티와 Dto 생성 시 Builder 패턴 적용 및 이에 따른 동작 코드 변경

### DIFF
--- a/server/src/main/java/com/jongyeop/soompyo/diary/controller/DiaryController.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/controller/DiaryController.java
@@ -1,5 +1,7 @@
 package com.jongyeop.soompyo.diary.controller;
 
+import java.util.Optional;
+
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,21 +10,32 @@ import org.springframework.web.bind.annotation.RestController;
 import com.jongyeop.soompyo.diary.dto.DiaryDto;
 import com.jongyeop.soompyo.diary.model.Diary;
 import com.jongyeop.soompyo.diary.service.DiaryService;
+import com.jongyeop.soompyo.user.model.TempUser;
+import com.jongyeop.soompyo.user.serivce.UserService;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @RestController
 @RequestMapping("/diarys")
 public class DiaryController {
 	private final DiaryService diaryService;
+	private final UserService userService;
 
-	public DiaryController(DiaryService diaryService) {
+	public DiaryController(DiaryService diaryService, UserService userService) {
 		this.diaryService = diaryService;
+		this.userService = userService;
 	}
 
 	@PostMapping
 	public DiaryDto saveDiary(@RequestBody DiaryDto diary) {
-		Diary savedDiary = diaryService.save(diary);
-		return new DiaryDto(savedDiary.getId(), savedDiary.getOwner().getId(), savedDiary.getTitle(),
-			savedDiary.getContent(),
-			savedDiary.getCreatedDate(), savedDiary.getModifiedDate());
+		Diary savedDiary = null;
+		Optional<TempUser> writer = userService.findById(diary.getOwner());
+		if (writer.isPresent()) {
+			savedDiary = diaryService.save(Diary.toEntity(diary, writer.get()));
+		}else{
+			throw new RuntimeException("사용자를 찾을 수 없습니다.");
+		}
+		return DiaryDto.toDto(savedDiary);
 	}
 }

--- a/server/src/main/java/com/jongyeop/soompyo/diary/dto/DiaryDto.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/dto/DiaryDto.java
@@ -1,46 +1,39 @@
 package com.jongyeop.soompyo.diary.dto;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import com.jongyeop.soompyo.diary.model.Diary;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class DiaryDto {
-	private final Long id;
-	private final Long owner;
-	private final String title;
-	private final String content;
-	private final LocalDateTime createdDate;
-	private final LocalDateTime modifiedDate;
+	private Long id;
+	private Long owner;
+	private String title;
+	private String content;
+	private LocalDate targetDate;
+	private LocalDateTime createdDate;
+	private LocalDateTime modifiedDate;
 
-	public DiaryDto(Long id, Long owner, String title, String content, LocalDateTime createdDate,
-		LocalDateTime modifiedDate) {
-		this.id = id;
-		this.owner = owner;
-		this.title = title;
-		this.content = content;
-		this.createdDate = createdDate;
-		this.modifiedDate = modifiedDate;
+
+	public static DiaryDto toDto(Diary entity) {
+		return DiaryDto.builder()
+			.id(entity.getId())
+			.title(entity.getTitle())
+			.owner(entity.getOwner().getId())
+			.content(entity.getContent())
+			.targetDate(entity.getTargetDate())
+			.createdDate(entity.getCreatedDate())
+			.modifiedDate(entity.getModifiedDate())
+			.build();
 	}
 
-	public Long getId() {
-		return id;
-	}
-
-	public Long getOwner() {
-		return owner;
-	}
-
-	public String getTitle() {
-		return title;
-	}
-
-	public String getContent() {
-		return content;
-	}
-
-	public LocalDateTime getCreatedDate() {
-		return createdDate;
-	}
-
-	public LocalDateTime getModifiedDate() {
-		return modifiedDate;
-	}
 }

--- a/server/src/main/java/com/jongyeop/soompyo/diary/model/Diary.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/model/Diary.java
@@ -3,6 +3,7 @@ package com.jongyeop.soompyo.diary.model;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import com.jongyeop.soompyo.diary.dto.DiaryDto;
 import com.jongyeop.soompyo.user.model.TempUser;
 
 import jakarta.persistence.Column;
@@ -14,6 +15,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,6 +23,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class Diary {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,5 +39,28 @@ public class Diary {
 	private LocalDate targetDate;
 	private LocalDateTime createdDate;
 	private LocalDateTime modifiedDate;
+
+	public static Diary toEntity(DiaryDto dto) {
+		return Diary.builder()
+			.id(dto.getId())
+			.title(dto.getTitle())
+			.content(dto.getContent())
+			.targetDate(dto.getTargetDate())
+			.createdDate(dto.getCreatedDate())
+			.modifiedDate(dto.getModifiedDate())
+			.build();
+	}
+
+	public static Diary toEntity(DiaryDto dto, TempUser owner) {
+		return Diary.builder()
+			.id(dto.getId())
+			.owner(owner)
+			.title(dto.getTitle())
+			.content(dto.getContent())
+			.targetDate(dto.getTargetDate())
+			.createdDate(dto.getCreatedDate())
+			.modifiedDate(dto.getModifiedDate())
+			.build();
+	}
 
 }

--- a/server/src/main/java/com/jongyeop/soompyo/diary/model/Diary.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/model/Diary.java
@@ -1,5 +1,6 @@
 package com.jongyeop.soompyo.diary.model;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.jongyeop.soompyo.user.model.TempUser;
@@ -12,8 +13,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Diary {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,41 +33,8 @@ public class Diary {
 
 	private String title;
 	private String content;
+	private LocalDate targetDate;
 	private LocalDateTime createdDate;
 	private LocalDateTime modifiedDate;
 
-	protected Diary() {
-	}
-
-	public Diary(TempUser owner, String title, String content, LocalDateTime createdDate, LocalDateTime modifiedDate) {
-		this.owner = owner;
-		this.title = title;
-		this.content = content;
-		this.createdDate = createdDate;
-		this.modifiedDate = modifiedDate;
-	}
-
-	public Long getId() {
-		return id;
-	}
-
-	public TempUser getOwner() {
-		return owner;
-	}
-
-	public String getTitle() {
-		return title;
-	}
-
-	public String getContent() {
-		return content;
-	}
-
-	public LocalDateTime getCreatedDate() {
-		return createdDate;
-	}
-
-	public LocalDateTime getModifiedDate() {
-		return modifiedDate;
-	}
 }

--- a/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryService.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryService.java
@@ -1,8 +1,7 @@
 package com.jongyeop.soompyo.diary.service;
 
-import com.jongyeop.soompyo.diary.dto.DiaryDto;
 import com.jongyeop.soompyo.diary.model.Diary;
 
 public interface DiaryService {
-	Diary save(DiaryDto diary);
+	Diary save(Diary diary);
 }

--- a/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryServiceImpl.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryServiceImpl.java
@@ -1,15 +1,9 @@
 package com.jongyeop.soompyo.diary.service;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
-
 import org.springframework.stereotype.Service;
 
-import com.jongyeop.soompyo.diary.dto.DiaryDto;
 import com.jongyeop.soompyo.diary.model.Diary;
 import com.jongyeop.soompyo.diary.repository.DiaryRepository;
-import com.jongyeop.soompyo.user.model.TempUser;
-import com.jongyeop.soompyo.user.repository.UserRepository;
 
 import jakarta.transaction.Transactional;
 
@@ -17,17 +11,13 @@ import jakarta.transaction.Transactional;
 @Transactional
 public class DiaryServiceImpl implements DiaryService {
 	private final DiaryRepository diaryRepository;
-	private final UserRepository userRepository;
 
-	public DiaryServiceImpl(DiaryRepository diaryRepository, UserRepository userRepository) {
+	public DiaryServiceImpl(DiaryRepository diaryRepository) {
 		this.diaryRepository = diaryRepository;
-		this.userRepository = userRepository;
 	}
 
 	@Override
-	public Diary save(DiaryDto diaryDto) {
-		Optional<TempUser> findUser = userRepository.findById(diaryDto.getOwner());
-		Diary diary = new Diary(findUser.get(), diaryDto.getTitle(), diaryDto.getContent(), LocalDateTime.now(), null);
+	public Diary save(Diary diary) {
 		return diaryRepository.save(diary);
 	}
 }

--- a/server/src/test/java/com/jongyeop/soompyo/diary/service/DiaryServiceTest.java
+++ b/server/src/test/java/com/jongyeop/soompyo/diary/service/DiaryServiceTest.java
@@ -1,6 +1,6 @@
 package com.jongyeop.soompyo.diary.service;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
@@ -29,7 +29,7 @@ public class DiaryServiceTest {
 	public void beforeEach() {
 		tempUserService
 			= new TempUserServiceImpl(tempUserRepository);
-		diaryService = new DiaryServiceImpl(diaryRepository, tempUserRepository);
+		diaryService = new DiaryServiceImpl(diaryRepository);
 	}
 
 	@Test
@@ -47,8 +47,9 @@ public class DiaryServiceTest {
 		if(!findUser.isPresent()) {
 			throw new RuntimeException("사용자를 찾을 수 없습니다.");
 		}
-		DiaryDto diary = new DiaryDto(null, findUser.get().getId(), title, content, null, null);
-		Diary savedDiary = diaryService.save(diary);
+		DiaryDto diaryDto = DiaryDto.builder().owner(findUser.get().getId()).title(title).content(content).targetDate(
+			LocalDate.of(2025, 3, 30)).build();
+		Diary savedDiary = diaryService.save(Diary.toEntity(diaryDto));
 
 		//then
 		Assertions.assertThat(savedDiary.getTitle()).isEqualTo(title);


### PR DESCRIPTION
[개요]
- Lombok 추가로 빌더 패턴을 사용하는 방식으로 변경 필요
- 그에 따른 내부 로직 변경 및 편의 메소드 추가
- 일기 지정요일 컬럼 추가
- Diary 엔티티 및 컨트롤러, 서비스 로직 변경으로 인해 테스트 변경 필요

[수정사항]
- Diary와 DiaryDto에 빌더 패턴 적용
- toEntity와 toDto 편의 메소드 정의
- 편의 메소드 정의에 따른 컨트롤러와 서비스 로직 일부 변경
- Diary 엔티티에 targetDate 컬럼 추가
- 변경된 방식에 맞춰 테스트 코드 수정

[결과]
- 컨트롤러와 서비스 계층 역할 분리
- 코드 간소화
- Entity <-> Dto 변환 편의성 제공
- 기억을 남기고자 하는 날 추가
- 변경된 방식에 맞는 테스트 진행 가능