### PR TITLE
Refactor: 기존 엔티티들에 롬복 적용

### DIFF
--- a/server/src/main/java/com/jongyeop/soompyo/diary/model/Diary.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/model/Diary.java
@@ -14,15 +14,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "diary")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class Diary {
 	@Id
@@ -34,10 +37,15 @@ public class Diary {
 	@JoinColumn(name = "id")
 	private TempUser owner;
 
+	@Column(name = "title")
 	private String title;
+	@Column(name = "content")
 	private String content;
+	@Column(name = "target_date")
 	private LocalDate targetDate;
+	@Column(name = "create_date")
 	private LocalDateTime createdDate;
+	@Column(name = "modified_data")
 	private LocalDateTime modifiedDate;
 
 	public static Diary toEntity(DiaryDto dto) {

--- a/server/src/main/java/com/jongyeop/soompyo/user/model/TempUser.java
+++ b/server/src/main/java/com/jongyeop/soompyo/user/model/TempUser.java
@@ -5,28 +5,32 @@ import java.util.List;
 
 import com.jongyeop.soompyo.diary.model.Diary;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TempUser {
-	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
 	private Long id;
+	@Column(name = "username")
 	private String username;
+	@Column(name = "user_id")
 	private String userId;
 
 	@OneToMany(mappedBy = "owner", fetch = FetchType.LAZY)
 	private List<Diary> diaries = new ArrayList<>();
-
-	protected TempUser() {
-
-	}
 
 	public TempUser(String userId, String username) {
 		this.userId = userId;

--- a/server/src/main/java/com/jongyeop/soompyo/user/model/TempUser.java
+++ b/server/src/main/java/com/jongyeop/soompyo/user/model/TempUser.java
@@ -11,8 +11,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class TempUser {
 	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -29,17 +31,5 @@ public class TempUser {
 	public TempUser(String userId, String username) {
 		this.userId = userId;
 		this.username = username;
-	}
-
-	public Long getId() {
-		return id;
-	}
-
-	public String getUsername() {
-		return username;
-	}
-
-	public String getUserId() {
-		return userId;
 	}
 }


### PR DESCRIPTION
[개요]
- 프로젝트에 롬복 라이브러리를 추가하면서 엔티티에 롬복을 적용하고자 함

[수정 사항]
- @Table과 Column을 사용해 엔티티와 테이블, 컬럼을 명시적으로 연결함
- 기본 생성자의 접근 지정자를 protected로 설정
- Getter 메소드를 모두 지우고, @Getter를 통해 getter를 정의

[결과]
- 어노테이션 기반 메소드 생성
- 기본 생성자의 public 접근을 막음