### PR TITLE
Refactor #6: 필드명 오타 수정 및 엔티티 생성 방식 개선

### DIFF
--- a/server/src/main/java/com/jongyeop/soompyo/diary/controller/DiaryController.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/controller/DiaryController.java
@@ -1,41 +1,35 @@
 package com.jongyeop.soompyo.diary.controller;
 
-import java.util.Optional;
+import java.util.List;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.jongyeop.soompyo.diary.dto.DiaryDto;
-import com.jongyeop.soompyo.diary.model.Diary;
+import com.jongyeop.soompyo.diary.dto.AddDiaryRequestDto;
+import com.jongyeop.soompyo.diary.dto.DiaryResponseDto;
 import com.jongyeop.soompyo.diary.service.DiaryService;
-import com.jongyeop.soompyo.user.model.TempUser;
-import com.jongyeop.soompyo.user.serivce.UserService;
 
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController
+@AllArgsConstructor
 @RequestMapping("/diarys")
 public class DiaryController {
 	private final DiaryService diaryService;
-	private final UserService userService;
 
-	public DiaryController(DiaryService diaryService, UserService userService) {
-		this.diaryService = diaryService;
-		this.userService = userService;
+	@GetMapping("/{userId}")
+	public List<DiaryResponseDto> getDiary(@PathVariable String userId) {
+		return diaryService.getDiariesByUserId(userId);
 	}
 
 	@PostMapping
-	public DiaryDto saveDiary(@RequestBody DiaryDto diary) {
-		Diary savedDiary = null;
-		Optional<TempUser> writer = userService.findById(diary.getOwner());
-		if (writer.isPresent()) {
-			savedDiary = diaryService.save(Diary.toEntity(diary, writer.get()));
-		}else{
-			throw new RuntimeException("사용자를 찾을 수 없습니다.");
-		}
-		return DiaryDto.toDto(savedDiary);
+	public DiaryResponseDto saveDiary(@RequestBody AddDiaryRequestDto diaryDto) {
+		return diaryService.save(diaryDto);
 	}
 }

--- a/server/src/main/java/com/jongyeop/soompyo/diary/dto/AddDiaryRequestDto.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/dto/AddDiaryRequestDto.java
@@ -1,0 +1,19 @@
+package com.jongyeop.soompyo.diary.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class AddDiaryRequestDto {
+	private String userId;
+	private String title;
+	private String content;
+	private LocalDate targetDate;
+	private LocalDateTime createdDate;
+}

--- a/server/src/main/java/com/jongyeop/soompyo/diary/dto/DiaryResponseDto.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/dto/DiaryResponseDto.java
@@ -14,9 +14,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class DiaryDto {
+public class DiaryResponseDto {
 	private Long id;
-	private Long owner;
+	private String owner;
 	private String title;
 	private String content;
 	private LocalDate targetDate;
@@ -24,11 +24,11 @@ public class DiaryDto {
 	private LocalDateTime modifiedDate;
 
 
-	public static DiaryDto toDto(Diary entity) {
-		return DiaryDto.builder()
+	public static DiaryResponseDto toDto(Diary entity) {
+		return DiaryResponseDto.builder()
 			.id(entity.getId())
 			.title(entity.getTitle())
-			.owner(entity.getOwner().getId())
+			.owner(entity.getOwner().getUserId())
 			.content(entity.getContent())
 			.targetDate(entity.getTargetDate())
 			.createdDate(entity.getCreatedDate())

--- a/server/src/main/java/com/jongyeop/soompyo/diary/model/Diary.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/model/Diary.java
@@ -3,7 +3,6 @@ package com.jongyeop.soompyo.diary.model;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-import com.jongyeop.soompyo.diary.dto.DiaryDto;
 import com.jongyeop.soompyo.user.model.TempUser;
 
 import jakarta.persistence.Column;
@@ -43,32 +42,9 @@ public class Diary {
 	private String content;
 	@Column(name = "target_date")
 	private LocalDate targetDate;
-	@Column(name = "create_date")
+	@Column(name = "created_date")
 	private LocalDateTime createdDate;
-	@Column(name = "modified_data")
+	@Column(name = "modified_date")
 	private LocalDateTime modifiedDate;
-
-	public static Diary toEntity(DiaryDto dto) {
-		return Diary.builder()
-			.id(dto.getId())
-			.title(dto.getTitle())
-			.content(dto.getContent())
-			.targetDate(dto.getTargetDate())
-			.createdDate(dto.getCreatedDate())
-			.modifiedDate(dto.getModifiedDate())
-			.build();
-	}
-
-	public static Diary toEntity(DiaryDto dto, TempUser owner) {
-		return Diary.builder()
-			.id(dto.getId())
-			.owner(owner)
-			.title(dto.getTitle())
-			.content(dto.getContent())
-			.targetDate(dto.getTargetDate())
-			.createdDate(dto.getCreatedDate())
-			.modifiedDate(dto.getModifiedDate())
-			.build();
-	}
 
 }

--- a/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryService.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryService.java
@@ -1,7 +1,12 @@
 package com.jongyeop.soompyo.diary.service;
 
-import com.jongyeop.soompyo.diary.model.Diary;
+import java.util.List;
+
+import com.jongyeop.soompyo.diary.dto.AddDiaryRequestDto;
+import com.jongyeop.soompyo.diary.dto.DiaryResponseDto;
 
 public interface DiaryService {
-	Diary save(Diary diary);
+	DiaryResponseDto save(AddDiaryRequestDto dto);
+
+	List<DiaryResponseDto> getDiariesByUserId(String userId);
 }

--- a/server/src/main/java/com/jongyeop/soompyo/user/model/TempUser.java
+++ b/server/src/main/java/com/jongyeop/soompyo/user/model/TempUser.java
@@ -3,6 +3,7 @@ package com.jongyeop.soompyo.user.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.jongyeop.soompyo.diary.model.Diary;
 
 import jakarta.persistence.Column;
@@ -24,12 +25,13 @@ public class TempUser {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "id")
 	private Long id;
-	@Column(name = "username")
+	@Column(name = "username", unique = true)
 	private String username;
-	@Column(name = "user_id")
+	@Column(name = "user_id", unique = true)
 	private String userId;
 
 	@OneToMany(mappedBy = "owner", fetch = FetchType.LAZY)
+	@JsonBackReference
 	private List<Diary> diaries = new ArrayList<>();
 
 	public TempUser(String userId, String username) {

--- a/server/src/main/java/com/jongyeop/soompyo/user/repository/UserRepository.java
+++ b/server/src/main/java/com/jongyeop/soompyo/user/repository/UserRepository.java
@@ -6,6 +6,11 @@ import com.jongyeop.soompyo.user.model.TempUser;
 
 public interface UserRepository {
 	TempUser save(TempUser user);
+
 	Optional<TempUser> findById(Long id);
+
 	Optional<TempUser> findByUsername(String username);
+
+	Optional<TempUser> findByUserId(String userId);
+
 }

--- a/server/src/main/java/com/jongyeop/soompyo/user/serivce/UserService.java
+++ b/server/src/main/java/com/jongyeop/soompyo/user/serivce/UserService.java
@@ -7,6 +7,6 @@ import com.jongyeop.soompyo.user.model.TempUser;
 public interface UserService {
 
 	TempUser join(TempUser tempUser);
-	Optional<TempUser> findById(Long userId);
+	Optional<TempUser> findById(Long Id);
 	Optional<TempUser> findByUsername(String username);
 }

--- a/server/src/test/java/com/jongyeop/soompyo/diary/service/DiaryServiceTest.java
+++ b/server/src/test/java/com/jongyeop/soompyo/diary/service/DiaryServiceTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-import com.jongyeop.soompyo.diary.dto.DiaryDto;
-import com.jongyeop.soompyo.diary.model.Diary;
+import com.jongyeop.soompyo.diary.dto.AddDiaryRequestDto;
+import com.jongyeop.soompyo.diary.dto.DiaryResponseDto;
 import com.jongyeop.soompyo.diary.repository.DiaryRepository;
 import com.jongyeop.soompyo.user.model.TempUser;
 import com.jongyeop.soompyo.user.repository.TempUserRepository;
@@ -29,7 +29,7 @@ public class DiaryServiceTest {
 	public void beforeEach() {
 		tempUserService
 			= new TempUserServiceImpl(tempUserRepository);
-		diaryService = new DiaryServiceImpl(diaryRepository);
+		diaryService = new DiaryServiceImpl(diaryRepository, tempUserRepository);
 	}
 
 	@Test
@@ -47,9 +47,9 @@ public class DiaryServiceTest {
 		if(!findUser.isPresent()) {
 			throw new RuntimeException("사용자를 찾을 수 없습니다.");
 		}
-		DiaryDto diaryDto = DiaryDto.builder().owner(findUser.get().getId()).title(title).content(content).targetDate(
+		AddDiaryRequestDto diaryResponseDto = AddDiaryRequestDto.builder().userId(findUser.get().getUserId()).title(title).content(content).targetDate(
 			LocalDate.of(2025, 3, 30)).build();
-		Diary savedDiary = diaryService.save(Diary.toEntity(diaryDto));
+		DiaryResponseDto savedDiary = diaryService.save(diaryResponseDto);
 
 		//then
 		Assertions.assertThat(savedDiary.getTitle()).isEqualTo(title);


### PR DESCRIPTION
[개요]
- modified_date의 오타 수정
- 객체 생성 방식을 builder를 이용해서 생성하는 방식으로 변경

[수정사항]
- 컬럼명 오타 수정
- toEntity 메소드 제거

[결과]
- DTO에서 엔티티화를 하지 않음