### PR TITLE
Refactor: 일기 엔티티 컬럼 추가 및 URI 변경

### DIFF
--- a/server/src/main/java/com/jongyeop/soompyo/diary/controller/DiaryController.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/controller/DiaryController.java
@@ -19,11 +19,11 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @AllArgsConstructor
-@RequestMapping("/diarys")
+@RequestMapping("/api/v1/users/{userId}/diaries")
 public class DiaryController {
 	private final DiaryService diaryService;
 
-	@GetMapping("/{userId}")
+	@GetMapping
 	public List<DiaryResponseDto> getDiary(@PathVariable String userId) {
 		return diaryService.getDiariesByUserId(userId);
 	}

--- a/server/src/main/java/com/jongyeop/soompyo/diary/model/Diary.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/model/Diary.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
+@Builder(toBuilder = true)
 public class Diary {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -46,5 +46,7 @@ public class Diary {
 	private LocalDateTime createdDate;
 	@Column(name = "modified_date")
 	private LocalDateTime modifiedDate;
+	@Column(name = "is_deleted")
+	private Boolean isDeleted;
 
 }

--- a/server/src/main/java/com/jongyeop/soompyo/user/controller/UserController.java
+++ b/server/src/main/java/com/jongyeop/soompyo/user/controller/UserController.java
@@ -3,20 +3,22 @@ package com.jongyeop.soompyo.user.controller;
 import com.jongyeop.soompyo.user.dto.TempUserDto;
 import com.jongyeop.soompyo.user.model.TempUser;
 import com.jongyeop.soompyo.user.serivce.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@RequestMapping("/user")
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users")
 public class UserController {
-    @Autowired
+
     private UserService userService;
 
-    @PostMapping("/signup")
+    @PostMapping("/signup") // 추후 분리 예정(-> auth)
     @ResponseBody
     public TempUserDto signup(@RequestBody TempUserDto requestUserDto) {
         TempUser tempUser = new TempUser(requestUserDto.getUserId(), requestUserDto.getUsername());


### PR DESCRIPTION
[개요]
- 사용자와 일기의 식별 관계를 명확하게 하기 위해 URI 변경 필요
- 일기 삭제를 soft delete로 진행하기 위해 추가적인 컬럼 필요

[수정 사항]
- 추후 서비스 확장할 수 있기에 API 버전을 URI에 명시
- 기존 /user 에서 /api/v1/users 로 변경
- 기존 /diarys 에서 api/v1/users/{userId}/diaries 로 URI 변경
- isDeleted 컬럼 추가
  - 일기의 삭제 여부를 저장하는 컬럼
  - 기본값을 false로 지정

[결과]
- 일기 엔티티에 isDeleted 컬럼 추가
- RESTFUL한 URI로 변경
