### PR TITLE
Feat: 일기 삭제 기능 추가

### DIFF
--- a/server/src/main/java/com/jongyeop/soompyo/diary/controller/DiaryController.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/controller/DiaryController.java
@@ -2,6 +2,7 @@ package com.jongyeop.soompyo.diary.controller;
 
 import java.util.List;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,5 +32,10 @@ public class DiaryController {
 	@PostMapping
 	public DiaryResponseDto saveDiary(@RequestBody AddDiaryRequestDto diaryDto) {
 		return diaryService.save(diaryDto);
+	}
+
+	@DeleteMapping("/{diaryId}")
+	public void deleteDiary(@PathVariable String userId, @PathVariable Long diaryId) {
+		diaryService.deleteDiaryById(userId, diaryId);
 	}
 }

--- a/server/src/main/java/com/jongyeop/soompyo/diary/model/Diary.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/model/Diary.java
@@ -49,4 +49,9 @@ public class Diary {
 	@Column(name = "is_deleted")
 	private Boolean isDeleted;
 
+	public void softDelete() {
+		this.isDeleted = true;
+		this.modifiedDate = LocalDateTime.now();
+	}
+
 }

--- a/server/src/main/java/com/jongyeop/soompyo/diary/repository/DiaryRepository.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/repository/DiaryRepository.java
@@ -1,5 +1,6 @@
 package com.jongyeop.soompyo.diary.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +9,6 @@ import com.jongyeop.soompyo.diary.model.Diary;
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 	Diary save(Diary diary);
+
+	Optional<Diary> findByIdAndOwnerUserId(Long diaryId, String ownerUserId);
 }

--- a/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryService.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryService.java
@@ -2,6 +2,8 @@ package com.jongyeop.soompyo.diary.service;
 
 import java.util.List;
 
+import org.springframework.http.ResponseEntity;
+
 import com.jongyeop.soompyo.diary.dto.AddDiaryRequestDto;
 import com.jongyeop.soompyo.diary.dto.DiaryResponseDto;
 
@@ -9,4 +11,6 @@ public interface DiaryService {
 	DiaryResponseDto save(AddDiaryRequestDto dto);
 
 	List<DiaryResponseDto> getDiariesByUserId(String userId);
+
+	ResponseEntity<Void> deleteDiaryById(String userId, Long diaryId);
 }

--- a/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryServiceImpl.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryServiceImpl.java
@@ -51,4 +51,13 @@ public class DiaryServiceImpl implements DiaryService {
 			throw new RuntimeException("사용자를 찾을 수 없습니다.");
 		}
 	}
+
+	@Override
+	@Transactional
+	public ResponseEntity<Void> deleteDiaryById(String userId, Long diaryId) {
+		Diary findDiary = diaryRepository.findByIdAndOwnerUserId(diaryId, userId)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "일기를 찾을 수 없습니다."));
+		findDiary.softDelete();
+		return ResponseEntity.noContent().build();
+	}
 }

--- a/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryServiceImpl.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;


### PR DESCRIPTION
[개요]
- 일기 삭제할 수 있는 기능을 추가
- 삭제 작업은 Soft Delete로 함

[수정 사항]
- 일기 Soft Delete 로직 추가

[결과]
- 일기 삭제 API 추가
  - URI: /api/v1/users/{userId}/diaries/{diaryId}
  - Method: Delete
  - Path Variable
    - userId: 사용자 아이디
    - diaryId: 일기 아이디
  - Response
    - 성공 시: noContent
    - 실패 시: Internal Server Error

[연관 이슈]
- #15 