### PR TITLE
Improve: 삭제된 일기는 조회하지 않음

### DIFF
--- a/server/src/main/java/com/jongyeop/soompyo/diary/repository/DiaryRepository.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/repository/DiaryRepository.java
@@ -1,5 +1,6 @@
 package com.jongyeop.soompyo.diary.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,7 +9,9 @@ import com.jongyeop.soompyo.diary.model.Diary;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-	Diary save(Diary diary);
+	Diary save(@Nonnull Diary diary);
 
 	Optional<Diary> findByIdAndOwnerUserId(Long diaryId, String ownerUserId);
+
+	Optional<List<Diary>> findByOwnerUserIdAndIsDeletedFalse(String userId);
 }

--- a/server/src/main/java/com/jongyeop/soompyo/diary/repository/DiaryRepository.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/repository/DiaryRepository.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Repository;
 
 import com.jongyeop.soompyo.diary.model.Diary;
 
+import jakarta.annotation.Nonnull;
+
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 	Diary save(@Nonnull Diary diary);

--- a/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryServiceImpl.java
+++ b/server/src/main/java/com/jongyeop/soompyo/diary/service/DiaryServiceImpl.java
@@ -27,10 +27,10 @@ public class DiaryServiceImpl implements DiaryService {
 
 	@Override
 	public List<DiaryResponseDto> getDiariesByUserId(String userId) {
-		TempUser user = userRepository.findByUserId(userId)
+		List<Diary> diaries = diaryRepository.findByOwnerUserIdAndIsDeletedFalse(userId)
 			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."));
 
-		return user.getDiaries().stream()
+		return diaries.stream()
 			.map(DiaryResponseDto::toDto)
 			.toList();
 	}


### PR DESCRIPTION
[개요]
- 일기 삭제 기능 추가에 따라 조회 시 삭제된 일기는 제외되어야 함
  - 일기를 Soft Delete 처리하기 때문

[수정 사항]
- 기존에 사용자의 일기 정보를 가져오는 로직에서 일기 리포지토리에서 가져오는 방식으로 변경

[결과]
- 일기 조회 시 삭제된 일기는 조회되지 않음

[연관 이슈]
- Closes #21 